### PR TITLE
Added support for cmake / conan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Git Ignore file
+
+
+.cproject
+.project
+.settings/
+.conan/
+docs/html/
+
+# CMake files
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+gen/
+
+# Recommended build directory
+build/
+Debug/
+.conan/
+
+# Compiler intermediate files
+*.o
+*.la
+*.so
+
+# Example files and binaries
+example
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+# This file (c) 2017 AlertAvert.com.  All rights reserved.
+
+project(SimpleHttpRequest)
+cmake_minimum_required(VERSION 3.4)
+
+# Version number
+set(RELEASE_MAJOR 0)
+set(RELEASE_MINOR 2)
+set(RELEASE_PATCH 0)
+
+# Use Conan for OpenSSL support.
+include(.conan/conanbuildinfo.cmake)
+conan_basic_setup()
+
+set(RELEASE_STRING "${RELEASE_MAJOR}.${RELEASE_MINOR}.${RELEASE_PATCH}-${BUILD_ID}")
+message(STATUS "Building Release: ${RELEASE_STRING}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+
+set(SRC ${CMAKE_SOURCE_DIR})
+
+set(HTTP_PARSER ${SRC}/http-parser)
+set(LIBUV ${SRC}/libuv)
+set(OPENSSL ${SRC}/openssl)
+
+include_directories(
+        ${SRC}
+        ${HTTP_PARSER}
+        ${LIBUV}/include
+        ${OPENSSL}/include
+)
+
+link_directories(${LIBUV}/.libs)
+set(LIBS
+        uv
+        pthread
+        crypto
+)
+
+#########
+# Examples - demo program.
+#########
+
+add_executable(example
+    ${SRC}/example.cpp
+    ${HTTP_PARSER}/http_parser.c
+)
+target_link_libraries(example ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,20 +21,22 @@ set(SRC ${CMAKE_SOURCE_DIR})
 
 set(HTTP_PARSER ${SRC}/http-parser)
 set(LIBUV ${SRC}/libuv)
-set(OPENSSL ${SRC}/openssl)
 
 include_directories(
         ${SRC}
         ${HTTP_PARSER}
         ${LIBUV}/include
-        ${OPENSSL}/include
 )
 
-link_directories(${LIBUV}/.libs)
+link_directories(
+        ${LIBUV}/.libs
+        ${HTTP_PARSER}
+)
 set(LIBS
-        uv
-        pthread
         crypto
+        http_parser
+        pthread
+        uv
 )
 
 #########
@@ -43,6 +45,5 @@ set(LIBS
 
 add_executable(example
     ${SRC}/example.cpp
-    ${HTTP_PARSER}/http_parser.c
 )
 target_link_libraries(example ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
-# This file (c) 2017 AlertAvert.com.  All rights reserved.
 
 project(SimpleHttpRequest)
 cmake_minimum_required(VERSION 3.4)
 
 # Version number
 set(RELEASE_MAJOR 0)
-set(RELEASE_MINOR 2)
+set(RELEASE_MINOR 1)
 set(RELEASE_PATCH 0)
 
-# Use Conan for OpenSSL support.
-include(.conan/conanbuildinfo.cmake)
-conan_basic_setup()
+# Uncomment the following lines to use Conan for OpenSSL support.
+#
+#  include(.conan/conanbuildinfo.cmake)
+#  conan_basic_setup()
 
 set(RELEASE_STRING "${RELEASE_MAJOR}.${RELEASE_MINOR}.${RELEASE_PATCH}-${BUILD_ID}")
 message(STATUS "Building Release: ${RELEASE_STRING}")

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ cd ..
 
 ### Using CMake & Conan package
 
+By uncommenting the lines in `CMakeLists.txt` as indicated, instead of having
+to build OpenSSL "in place," we can use Conan package manager.
+
 See [conan.io](http://conan.io) for more details; the TL;dr is `pip install conan`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ cd ..
 # cd openssl && ./config && make
 ```
 
+### Using CMake & Conan package
+
+See [conan.io](http://conan.io) for more details; the TL;dr is `pip install conan`.
+
+```bash
+# Create the .so library for http-parser:
+cd http-parser && make library
+ln -s libhttp_parser.so.2.7.1 libhttp_parser.so
+
+# Build the package dependencies; currently just OpenSSL
+mkdir .conan && cd .conan
+conan install .. -s compiler=clang -s compiler.version=4.0 \
+    -s compiler.libcxx=libstdc++11 --build=missing
+
+# Build the example binary.
+mkdir build && cd build
+cmake .. && cmake --build .
+```
+
+`TODO: install step in CMake & detailed instruction how to use this in a C++ project`
+
 ### example.cpp - http
 ```bash
 $ make

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,14 @@
+# Conan Packaging configuration.
+# Created by M. Massenzio
+#
+# See the README for more information or http://conan.io
+#
+#   $ conan install .. -s compiler=clang -s compiler.version=4.0 \
+#      -s compiler.libcxx=libstdc++11 --build=missing
+
+
+[requires]
+OpenSSL/1.0.2j@lasote/stable
+
+[generators]
+cmake


### PR DESCRIPTION
Hi,

thanks for putting this together - much appreciated!

I thought I'd contribute back by adding support for CMake & adding `conan` (see http://conan.io ) so that you could remove the OpenSSL git submodule.

BTW - the `example` runs into a weird `parse error` when used against google.com, but it works just fine when used against my [own server](https://github.com/massenz/distlib) and returns the correct JSON content - not sure why.